### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,71 @@
-# WooCommerce
-Payment Module for WooCommerce
+=== Twispay Credit Card Payments ===
+Contributors: twispay
+Tags: payment, gateway, module
+Requires at least: 4.6
+Tested up to: 5.3
+
+Twispay enables new and existing store owners to quickly and effortlessly accept online credit card payments over their WooCommerce shop
+
+== Description ==
+
+[Twispay](https://www.twispay.com) is a European certified acquiring bank with a sleek payment gateway optimized for online shops. We process payments from worldwide customers using Mastercard or Visa debit and credit cards. Increase your purchases by using our conversion rate optimized checkout flow and manage your transactions with our dashboard created specifically for online merchants like you. Twispay Credit Card Payments is the official payment module built for WooCommerce
+
+Our WooCommerce payment extension allows for fast and easy integration with the Twispay Payment Gateway. Quickly start accepting online credit card payments through a secure environment and a fully customizable checkout process. Give your customers the shopping experience they expect, and boost your online sales with our simple and elegant payment plugin.
+
+For more details concerning our pricing in your region, please check out our [pricing page](https://www.twispay.com/prices). To use our payment module and start processing you will need a Twispay [merchant account](https://www.twispay.com/signup). For any assistance during the on-boarding process, our [sales and compliance](https://www.twispay.com/contact-twispay) team are happy to respond to any enquiries you may have.
+
+== Installation ==
+
+The easiest way of installing our module is by visiting the [official module page](https://wordpress.org/plugins/twispay/).
+Alternatively, you can check out our [installation guide](https://twis.li/2ueQ6Rz) for detailed step by step instructions.
+1. Log into your WordPress site.
+2. Go to: Plugins > Add New.
+3. Search for "Twispay".
+4. Select "Install Now" when you see it’s by twispay.
+5. Select "Activate Now" and you’re ready for customization.
+6. Go to: Twispay
+7. Select **Yes** under **Live mode**. _(Unless you are testing)_
+8. Enter your **Site ID**. _(Twispay Staging Account ID: You can get one from [here for live](https://merchant.twispay.com/login) or from [here for stage](https://merchant-stage.twispay.com/login))_
+9. Enter your **Private Key**. _(Twispay Secret Key: You can get one from [here for live](https://merchant.twispay.com/login) or from [here for stage](https://merchant-stage.twispay.com/login))_
+10. Select the custom page you want to redirect the customer after the payment **Redirect to custom page Thank you page**. _(Leave 'Default' to redirect to order confirmation default page.)_
+11. Enter your tehnical **Contact Email**. _(This will be displayed to customers in case of a payment error)_
+12. Save your changes.
+
+== Screenshots ==
+
+1. Secure credit card processing for Visa and Mastercard
+2. Quick and easy installation
+3. Fully customizable checkout experience
+
+== Changelog ==
+
+= 1.0.8 =
+* Updated unique identifiers to reflect the request type (purchase or recurrent) and the source plugin.
+* Appended the timestamp to the orderId that is encapsulated inside the payment request to ensure unicity.
+* Tested with Wordpress 5.3
+
+= 1.0.7 =
+* Bugfix: Added die('OK') at the end of the file that processes the IPN response.
+* Bugfix: Added the 'timestamp' to the 'identifier' when it is built for an authenticated customer.
+
+= 1.0.6 =
+* Version bump
+
+= 1.0.5 =
+* Moved all the subscription status update code to a dedicated object
+* Added support for the Woocommerce Subscriptions
+* Added support for refunds
+
+= 1.0.4 =
+* Added new log, general and admin messages
+* Updated the server response handling to process all the possible server response statuses
+
+= 1.0.3 =
+* Updated the way parameters are sent to address a bug that was failing transactions when names had special characters
+
+= 0.0.1 =
+* Initial Plugin version
+* Merchant config interface
+* Integration with Twispay's Secure Hosted Payment Page
+* Listening URL which accepts the server’s Instant Payment Notifications
+* Replaced FORM used for server notification with JSON

--- a/Twispay WooCommerce Plugin/twispay/README.md
+++ b/Twispay WooCommerce Plugin/twispay/README.md
@@ -2,8 +2,8 @@
 Contributors: twispay
 Tags: payment, gateway, module
 Requires at least: 4.6
-Tested up to: 4.8
- 
+Tested up to: 5.3
+
 Twispay enables new and existing store owners to quickly and effortlessly accept online credit card payments over their WooCommerce shop
 
 == Description ==
@@ -15,21 +15,41 @@ Our WooCommerce payment extension allows for fast and easy integration with the 
 For more details concerning our pricing in your region, please check out our [pricing page](https://www.twispay.com/prices). To use our payment module and start processing you will need a Twispay [merchant account](https://www.twispay.com/signup). For any assistance during the on-boarding process, our [sales and compliance](https://www.twispay.com/contact-twispay) team are happy to respond to any enquiries you may have.
 
 == Installation ==
- 
+
 The easiest way of installing our module is by visiting the [official module page](https://wordpress.org/plugins/twispay/).
 Alternatively, you can check out our [installation guide](https://twis.li/2ueQ6Rz) for detailed step by step instructions.
+1. Log into your WordPress site.
+2. Go to: Plugins > Add New.
+3. Search for "Twispay".
+4. Select "Install Now" when you see it’s by twispay.
+5. Select "Activate Now" and you’re ready for customization.
+6. Go to: Twispay
+7. Select **Yes** under **Live mode**. _(Unless you are testing)_
+8. Enter your **Site ID**. _(Twispay Staging Account ID: You can get one from [here for live](https://merchant.twispay.com/login) or from [here for stage](https://merchant-stage.twispay.com/login))_
+9. Enter your **Private Key**. _(Twispay Secret Key: You can get one from [here for live](https://merchant.twispay.com/login) or from [here for stage](https://merchant-stage.twispay.com/login))_
+10. Select the custom page you want to redirect the customer after the payment **Redirect to custom page Thank you page**. _(Leave 'Default' to redirect to order confirmation default page.)_
+11. Enter your tehnical **Contact Email**. _(This will be displayed to customers in case of a payment error)_
+12. Save your changes.
 
 == Screenshots ==
- 
+
 1. Secure credit card processing for Visa and Mastercard
 2. Quick and easy installation
 3. Fully customizable checkout experience
 
 == Changelog ==
 
-= 1.0.6 =
+= 1.0.8 =
+* Updated unique identifiers to reflect the request type (purchase or recurrent) and the source plugin.
+* Appended the timestamp to the orderId that is encapsulated inside the payment request to ensure unicity.
+* Tested with Wordpress 5.3
+
+= 1.0.7 =
 * Bugfix: Added die('OK') at the end of the file that processes the IPN response.
 * Bugfix: Added the 'timestamp' to the 'identifier' when it is built for an authenticated customer.
+
+= 1.0.6 =
+* Version bump
 
 = 1.0.5 =
 * Moved all the subscription status update code to a dedicated object

--- a/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Default_Thankyou.php
+++ b/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Default_Thankyou.php
@@ -6,8 +6,8 @@
  *
  * @package  Twispay/Front
  * @category Front
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 /* Exit if the file is accessed directly. */
@@ -17,10 +17,6 @@ if ( !defined('ABSPATH') ) { exit; }
 if ( ! class_exists( 'Twispay_TW_Default_Thankyou' ) ) :
     /**
      * Twispay Helper Class
-     *
-     * @class   Twispay_TW_Default_Thankyou
-     * @version 0.0.1
-     *
      *
      * Class that redirects user to the order page.
      */

--- a/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Helper_Notify.php
+++ b/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Helper_Notify.php
@@ -6,8 +6,8 @@
  *
  * @package  Twispay/Front
  * @category Front
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 /* Exit if the file is accessed directly. */
@@ -17,10 +17,6 @@ if ( !defined('ABSPATH') ) { exit; }
 if ( ! class_exists( 'Twispay_TW_Helper_Notify' ) ) :
     /**
      * Twispay Helper Class
-     *
-     * @class   Twispay_TW_Helper_Notify
-     * @version 0.0.1
-     *
      *
      * Class that implements methods to get the value
      * of `jsonRequest` and `checksum` that need to be

--- a/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Helper_Response.php
+++ b/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Helper_Response.php
@@ -30,11 +30,12 @@ if ( !class_exists( 'Twispay_TW_Helper_Response' ) ) :
          *
          * @param string $tw_encryptedMessage - The encripted server message.
          * @param string $tw_secretKey        - The secret key (from Twispay).
+         * @param array $tw_lang              - The language that the store uses
          *
          * @return Array([key => value,]) - If everything is ok array containing the decrypted data.
          *         bool(FALSE)            - If decription fails.
          */
-        public static function twispay_tw_decrypt_message($tw_encryptedMessage, $tw_secretKey){
+        public static function twispay_tw_decrypt_message($tw_encryptedMessage, $tw_secretKey, $tw_lang){
             $encrypted = ( string )$tw_encryptedMessage;
 
             if ( !strlen($encrypted) || (FALSE == strpos($encrypted, ',')) ){
@@ -64,6 +65,53 @@ if ( !class_exists( 'Twispay_TW_Helper_Response' ) ) :
 
             /** Check if the decryption was successful. */
               if (NULL === $decodedResponse) {
+                /** Log the last error occurred during the last JSON encoding/decoding. */
+                switch (json_last_error()) {
+                    case JSON_ERROR_DEPTH:
+                        Twispay_TW_Logger::twispay_tw_log($tw_lang['JSON_ERROR_DEPTH']);
+                    break;
+
+                    case JSON_ERROR_STATE_MISMATCH:
+                        Twispay_TW_Logger::twispay_tw_log($tw_lang['JSON_ERROR_STATE_MISMATCH']);
+                    break;
+
+                    case JSON_ERROR_CTRL_CHAR:
+                        Twispay_TW_Logger::twispay_tw_log($tw_lang['JSON_ERROR_CTRL_CHAR']);
+                    break;
+
+                    case JSON_ERROR_SYNTAX:
+                        Twispay_TW_Logger::twispay_tw_log($tw_lang['JSON_ERROR_SYNTAX']);
+                    break;
+
+                    case JSON_ERROR_UTF8:
+                        Twispay_TW_Logger::twispay_tw_log($tw_lang['JSON_ERROR_UTF8']);
+                    break;
+
+                    case JSON_ERROR_RECURSION:
+                        Twispay_TW_Logger::twispay_tw_log($tw_lang['JSON_ERROR_RECURSION']);
+                    break;
+
+                    case JSON_ERROR_INF_OR_NAN:
+                        Twispay_TW_Logger::twispay_tw_log($tw_lang['JSON_ERROR_INF_OR_NAN']);
+                    break;
+
+                    case JSON_ERROR_UNSUPPORTED_TYPE:
+                        Twispay_TW_Logger::twispay_tw_log($tw_lang['JSON_ERROR_UNSUPPORTED_TYPE']);
+                    break;
+
+                    case JSON_ERROR_INVALID_PROPERTY_NAME:
+                        Twispay_TW_Logger::twispay_tw_log($tw_lang['JSON_ERROR_INVALID_PROPERTY_NAME']);
+                    break;
+
+                    case JSON_ERROR_UTF16:
+                        Twispay_TW_Logger::twispay_tw_log($tw_lang['JSON_ERROR_UTF16']);
+                    break;
+
+                    default:
+                        Twispay_TW_Logger::twispay_tw_log($tw_lang['JSON_ERROR_UNKNOWN']);
+                    break;
+                }
+
                 return FALSE;
             }
 

--- a/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Helper_Response.php
+++ b/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Helper_Response.php
@@ -6,8 +6,8 @@
  *
  * @package  Twispay/Front
  * @category Front
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 /* Exit if the file is accessed directly. */
@@ -20,10 +20,6 @@ require_once( TWISPAY_PLUGIN_DIR . DIRECTORY_SEPARATOR . 'helpers' . DIRECTORY_S
 if ( !class_exists( 'Twispay_TW_Helper_Response' ) ) :
     /**
      * Twispay Helper Class
-     *
-     * @class   Twispay_TW_Helper_Response
-     * @version 0.0.1
-     *
      *
      * Class that implements methods to decrypt
      * Twispay server responses.
@@ -63,8 +59,25 @@ if ( !class_exists( 'Twispay_TW_Helper_Response' ) ) :
                 return FALSE;
             }
 
-            /* JSON decode the decrypted data. */
-            return json_decode($decryptedResponse, /*assoc*/TRUE, /*depth*/4);
+            /** JSON decode the decrypted data. */
+            $decodedResponse = json_decode($decryptedResponse, /*assoc*/TRUE, /*depth*/4);
+
+            /** Check if the decryption was successful. */
+              if (NULL === $decodedResponse) {
+                return FALSE;
+            }
+
+            /** Check if externalOrderId uses '_' separator */
+            if (FALSE !== strpos($decodedResponse['externalOrderId'], '_')) {
+                $explodedVal = explode('_', $decodedResponse['externalOrderId'])[0];
+
+                /** Check if externalOrderId contains only digits and is not empty. */
+                if (!empty($explodedVal) && ctype_digit($explodedVal)) {
+                    $decodedResponse['externalOrderId'] = $explodedVal;
+                }
+            }
+
+            return $decodedResponse;
         }
 
 

--- a/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Logger.php
+++ b/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Logger.php
@@ -6,8 +6,8 @@
  *
  * @package  Twispay/Front
  * @category Front
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 /* Exit if the file is accessed directly. */
@@ -17,10 +17,6 @@ if ( !defined('ABSPATH') ) { exit; }
 if ( ! class_exists( 'Twispay_TW_Logger' ) ) :
     /**
      * Twispay Helper Class
-     *
-     * @class   Twispay_TW_Logger
-     * @version 0.0.1
-     *
      *
      * Class that implements methods to log
      * messages and transactions.
@@ -41,10 +37,10 @@ if ( ! class_exists( 'Twispay_TW_Logger' ) ) :
 
             $already = $wpdb->get_row( "SELECT * FROM " . $wpdb->prefix . "twispay_tw_transactions WHERE transactionId = '" . $data['transactionId'] . "'" );
             if ( $already ) {
-              /* Update the DB with the transaction data. */
-              $wpdb->query( $wpdb->prepare( "UPDATE " . $wpdb->prefix . "twispay_tw_transactions SET status = '" . $data['status'] . "' WHERE transactionId = '%d'", $data['transactionId'] ) );
+                /* Update the DB with the transaction data. */
+                $wpdb->query( $wpdb->prepare( "UPDATE " . $wpdb->prefix . "twispay_tw_transactions SET status = '" . $data['status'] . "' WHERE transactionId = '%d'", $data['transactionId'] ) );
             } else {
-                $checkout_url = ((false !== $order) && (true !== $order)) ? (wc_get_checkout_url() . 'order-pay/' . explode('_', $data['id_cart'])[0] . '/?pay_for_order=true&key=' . $order->get_data()['order_key'] . '&tw_reload=true') : ("");
+                $checkout_url = ((false !== $order) && (true !== $order)) ? (wc_get_checkout_url() . 'order-pay/' . explode('_', $data['id_cart'])[0] . '/?pay_for_order=true&key=' . $order->get_data()['order_key']) : ("");
                 $wpdb->get_results( "INSERT INTO `" . $wpdb->prefix . "twispay_tw_transactions` (`status`, `id_cart`, `identifier`, `orderId`, `transactionId`, `customerId`, `cardId`, `checkout_url`) VALUES ('" . $data['status'] . "', '" . $data['id_cart'] . "', '" . $data['identifier'] . "', '" . $data['orderId'] . "', '" . $data['transactionId'] . "', '" . $data['customerId'] . "', '" . $data['cardId'] . "', '" . $checkout_url . "');" );
             }
         }

--- a/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Status_Updater.php
+++ b/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Status_Updater.php
@@ -2,13 +2,13 @@
 /**
  * Twispay Helpers
  *
- * Updates the statused of orders and subscriptions based 
+ * Updates the statused of orders and subscriptions based
  *  on the status read from the server response.
  *
  * @package  Twispay/Front
  * @category Front
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 /* Exit if the file is accessed directly. */
@@ -19,12 +19,8 @@ if ( ! class_exists( 'Twispay_TW_Status_Updater' ) ) :
     /**
      * Twispay Helper Class
      *
-     * @class   Twispay_TW_Status_Updater
-     * @version 0.0.1
-     *
-     *
      * Class that implements methods to update the statuses
-     * of orders and subscriptions based on the status received 
+     * of orders and subscriptions based on the status received
      * from the server.
      */
     class Twispay_TW_Status_Updater{
@@ -201,11 +197,11 @@ if ( ! class_exists( 'Twispay_TW_Status_Updater' ) ) :
                     if(class_exists('WC_Subscriptions') && wcs_order_contains_subscription($order)){
                       $subscription = wcs_get_subscriptions_for_order($order);
                       $subscription = reset($subscription);
-  
+
                       /* First payment on order, process payment & activate subscription. */
                       if ( 0 == $subscription->get_completed_payment_count() ) {
                           $order->payment_complete();
-  
+
                           if(class_exists('WC_Subscriptions') ){
                               WC_Subscriptions_Manager::activate_subscriptions_for_order( $order );
                           }

--- a/Twispay WooCommerce Plugin/twispay/includes/a-functions.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/a-functions.php
@@ -6,13 +6,13 @@
  *
  * @package  Twispay/Admin
  * @category Admin
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 /**
  * Retrieves Live Mode options from Configuration Panel
- * 
+ *
  * @public
  * @return string Html with all Live Mode options
  */
@@ -22,7 +22,7 @@ function twispay_tw_get_live_mode( $tw_lang ) {
     $html = '';
 
     $live_mode = $wpdb->get_results( "SELECT live_mode FROM " . $wpdb->prefix . "twispay_tw_configuration" );
-    
+
     if ( $live_mode ) {
         $html .= '<select name="live_mode" id="live_mode">';
         foreach ( $live_mode as $e_l ) {
@@ -34,11 +34,11 @@ function twispay_tw_get_live_mode( $tw_lang ) {
                 $html .= '<option value="1">' . $tw_lang['live_mode_option_true'] . '</option>';
                 $html .= '<option value="0"selected>' . $tw_lang['live_mode_option_false'] . '</option>';
             }
-            
+
             break;
         }
         $html .= '</select>';
-        
+
         return $html;
     }
     else {
@@ -46,20 +46,20 @@ function twispay_tw_get_live_mode( $tw_lang ) {
         $wpdb->insert( $wpdb->prefix . 'twispay_tw_configuration', array(
             'live_mode'     => 0
         ) );
-        
+
         // Now display the default form
         $html .= '<select name="live_mode" id="live_mode">';
         $html .= '<option value="1">' . $tw_lang['live_mode_option_true'] . '</option>';
         $html .= '<option value="0" selected>' . $tw_lang['live_mode_option_false'] . '</option>';
         $html .= '</select>';
-        
+
         return $html;
     }
 }
 
 /**
  * Retrieves Suppress Email options from Configuration Panel
- * 
+ *
  * @public
  * @return string Html with all Suppress Email options
  */
@@ -69,7 +69,7 @@ function twispay_tw_get_suppress_email( $tw_lang ) {
     $html = '';
 
     $suppress_email = $wpdb->get_results( "SELECT suppress_email FROM " . $wpdb->prefix . "twispay_tw_configuration" );
-    
+
     if ( $suppress_email ) {
         $html .= '<select name="suppress_email" id="suppress_email">';
         foreach ( $suppress_email as $e_s ) {
@@ -81,18 +81,18 @@ function twispay_tw_get_suppress_email( $tw_lang ) {
                 $html .= '<option value="1">' . $tw_lang['live_mode_option_true'] . '</option>';
                 $html .= '<option value="0"selected>' . $tw_lang['live_mode_option_false'] . '</option>';
             }
-            
+
             break;
         }
         $html .= '</select>';
-        
+
         return $html;
     }
 }
 
 /**
  * Retrieves all Wordpress Pages for configuring Thank you redirect
- * 
+ *
  * @public
  * @return string Html with all Wordpress Pages options
  */
@@ -103,11 +103,11 @@ function twispay_tw_get_wp_pages( $tw_lang ) {
 
     $configuration = $wpdb->get_results( "SELECT thankyou_page FROM " . $wpdb->prefix . "twispay_tw_configuration" );
     $wp_pages = $wpdb->get_results( "SELECT post_title, guid FROM " . $wpdb->prefix . "posts WHERE post_type = 'page' AND post_status = 'publish' " );
-    
+
     if ( $wp_pages ) {
         $html .= '<select name="wp_pages" id="wp_pages">';
         $html .= '<option value="0">' . $tw_lang['get_all_wordpress_pages_default'] . '</option>';
-        
+
         foreach ( $wp_pages as $e_p ) {
             if ( $e_p->post_title != 'Twispay confirmation' ) {
                 if ( $configuration ) {
@@ -124,23 +124,23 @@ function twispay_tw_get_wp_pages( $tw_lang ) {
             }
         }
         $html .= '</select>';
-        
+
         return $html;
     }
 }
 
 /**
  * Retrieves Contact email on the current Shop
- * 
+ *
  * @public
  * @return string contact_email
  */
 function twispay_tw_get_contact_email_o() {
     // Wordpress database refference
     global $wpdb;
-    
+
     $contact_email = $wpdb->get_results( "SELECT contact_email FROM " . $wpdb->prefix . "twispay_tw_configuration" );
-    
+
     if ( $contact_email ) {
         return $contact_email[0]->contact_email;
     }
@@ -151,16 +151,16 @@ function twispay_tw_get_contact_email_o() {
 
 /**
  * Retrieves Staging Site ID on the current Shop
- * 
+ *
  * @public
  * @return string staging_id
  */
 function twispay_tw_get_staging_site_id() {
     // Wordpress database refference
     global $wpdb;
-    
+
     $staging_id = $wpdb->get_results( "SELECT staging_id FROM " . $wpdb->prefix . "twispay_tw_configuration" );
-    
+
     if ( $staging_id ) {
         return $staging_id[0]->staging_id;
     }
@@ -171,16 +171,16 @@ function twispay_tw_get_staging_site_id() {
 
 /**
  * Retrieves Staging Private Key on the current Shop
- * 
+ *
  * @public
  * @return string staging_key
  */
 function twispay_tw_get_staging_private_key() {
     // Wordpress database refference
     global $wpdb;
-    
+
     $staging_key = $wpdb->get_results( "SELECT staging_key FROM " . $wpdb->prefix . "twispay_tw_configuration" );
-    
+
     if ( $staging_key ) {
         return $staging_key[0]->staging_key;
     }
@@ -191,16 +191,16 @@ function twispay_tw_get_staging_private_key() {
 
 /**
  * Retrieves Live Site ID on the current Shop
- * 
+ *
  * @public
  * @return string live_id
  */
 function twispay_tw_get_live_site_id() {
     // Wordpress database refference
     global $wpdb;
-    
+
     $live_id = $wpdb->get_results( "SELECT live_id FROM " . $wpdb->prefix . "twispay_tw_configuration" );
-    
+
     if ( $live_id ) {
         return $live_id[0]->live_id;
     }
@@ -211,16 +211,16 @@ function twispay_tw_get_live_site_id() {
 
 /**
  * Retrieves Live Private Key on the current Shop
- * 
+ *
  * @public
  * @return string live_key
  */
 function twispay_tw_get_live_private_key() {
     // Wordpress database refference
     global $wpdb;
-    
+
     $live_key = $wpdb->get_results( "SELECT live_key FROM " . $wpdb->prefix . "twispay_tw_configuration" );
-    
+
     if ( $live_key ) {
         return $live_key[0]->live_key;
     }

--- a/Twispay WooCommerce Plugin/twispay/includes/admin/admin-requests.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/admin/admin-requests.php
@@ -6,8 +6,8 @@
  *
  * @package  Twispay/Admin
  * @category Admin
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 /**
@@ -21,17 +21,17 @@ function twispay_tw_main_action() {
     // Check if there is a form process in rolling
     if ( isset( $_REQUEST['tw_general_action'] ) ) {
         $request = $_REQUEST['tw_general_action'];
-        
+
         // Check if current user have administrator permisions. If not, throw 403 error
         if ( ! current_user_can( 'administrator' ) ) {
             wp_die( __( 'You do not have permission to access this file', 'twispay' ), __( 'Error', 'twispay' ), array( 'response' => 403 ) );
         }
-        
+
         // Check if you are viewing the WordPress Administration Panels
         if ( ! is_admin() ) {
             wp_die( __( 'You do not have permission to access the file from here', 'twispay' ), __( 'Error', 'twispay' ), array( 'response' => 403 ) );
         }
-        
+
         // Pass the request to their own controllers. This call is dynamic and have following form. Eg: "tw_" + <the_request_name>. If we want to start the edit the configuration, the request will be like "edit_general_configuration"
         do_action( 'tw_' . $request, $_REQUEST );
     }

--- a/Twispay WooCommerce Plugin/twispay/includes/admin/configuration/configuration.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/admin/configuration/configuration.php
@@ -6,8 +6,8 @@
  *
  * @package  Twispay/Admin
  * @category Admin
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 // Exit if the file is accessed directly
@@ -24,7 +24,7 @@ function twispay_tw_configuration() {
     } else {
         require( TWISPAY_PLUGIN_DIR . 'lang/en/lang.php' );
     }
-    
+
     if ( ! class_exists( 'WooCommerce' ) ) {
         ?>
             <div class="error notice" style="margin-top: 20px;">

--- a/Twispay WooCommerce Plugin/twispay/includes/admin/configuration/requests.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/admin/configuration/requests.php
@@ -4,10 +4,10 @@
  *
  * Here is processed all configuration actions( edit )
  *
- * @package  Twispay/Admin
+ * @package Twispay_Payment_Gateway
  * @category Admin
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 /**
@@ -37,22 +37,22 @@ function tw_twispay_p_edit_general_configuration( $request ) {
     $thankyou_page = $request['wp_pages'];
     $suppress_email = $request['suppress_email'];
     $contact_email_o = $request['contact_email_o'];
-    
+
     if ( $contact_email_o == '' ) {
         $contact_email_o = 0;
     }
-    
+
     // Wordpress database refference
     global $wpdb;
-    
+
     // Check if the Configuration row exist into Database
     $configuration = $wpdb->get_results( "SELECT * FROM " . $wpdb->prefix . "twispay_tw_configuration" );
-    
+
     if ( $configuration ) {
         // Edit the Configuration into Database ( twispay_tw_configuration table )
-        $wpdb->update( 
-            $wpdb->prefix . 'twispay_tw_configuration', 
-            array( 
+        $wpdb->update(
+            $wpdb->prefix . 'twispay_tw_configuration',
+            array(
                 'live_mode'       => $live_mode,
                 'staging_id'      => $staging_site_id,
                 'staging_key'     => $staging_private_key,
@@ -61,7 +61,7 @@ function tw_twispay_p_edit_general_configuration( $request ) {
                 'thankyou_page'   => $thankyou_page,
                 'suppress_email'  => $suppress_email,
                 'contact_email'  => $contact_email_o
-            ), 
+            ),
             array(
                 'id_tw_configuration'  => $configuration[0]->id_tw_configuration
             )
@@ -74,9 +74,9 @@ function tw_twispay_p_edit_general_configuration( $request ) {
         ) );
 
         // Edit the Configuration into Database ( twispay_tw_configuration table )
-        $wpdb->update( 
-            $wpdb->prefix . 'twispay_tw_configuration', 
-            array( 
+        $wpdb->update(
+            $wpdb->prefix . 'twispay_tw_configuration',
+            array(
                 'live_mode'       => $live_mode,
                 'staging_id'      => $staging_site_id,
                 'staging_key'     => $staging_private_key,
@@ -85,7 +85,7 @@ function tw_twispay_p_edit_general_configuration( $request ) {
                 'thankyou_page'   => $thankyou_page,
                 'suppress_email'  => $suppress_email,
                 'contact_email'  => $contact_email_o
-            ), 
+            ),
             array(
                 'id_tw_configuration'  => $wpdb->insert_id
             )

--- a/Twispay WooCommerce Plugin/twispay/includes/admin/ma-class-menu.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/admin/ma-class-menu.php
@@ -6,13 +6,13 @@
  *
  * @package  Twispay/Admin
  * @category Admin
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 // Exit if the file is accessed directly
-if ( ! defined( 'ABSPATH' ) ) { 
-    exit; 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
 }
 
 // Security class check
@@ -20,9 +20,6 @@ if ( ! class_exists( 'Twispay_Tw_Admin_Menu' ) ) :
 
 /**
  * Dashboard Menus Twispay_Tw_Admin_Menu Class.
- *
- * @class Twispay_Tw_Admin_Menu
- * @version	0.0.1
  */
 class Twispay_Tw_Admin_Menu {
     /**
@@ -36,7 +33,7 @@ class Twispay_Tw_Admin_Menu {
     public function __construct() {
         add_action( 'admin_menu', array( $this, 'admin_menu' ) );
     }
-    
+
     /**
      * Function that will add the menus items, as well the submenus
      *
@@ -52,10 +49,10 @@ class Twispay_Tw_Admin_Menu {
         } else {
             require( TWISPAY_PLUGIN_DIR . 'lang/en/lang.php' );
         }
-        
+
         // Add main adminsitrator page
         add_menu_page( __( 'Twispay', 'twispay' ), __( $tw_lang['menu_main_title'], 'twispay' ), 'administrator', 'twispay', 'twispay_tw_configuration', 'dashicons-editor-paste-text', 1000 );
-        
+
         // Add submenus
         add_submenu_page( 'twispay', __( $tw_lang['menu_configuration_tab'], 'twispay' ), __( $tw_lang['menu_configuration_tab'], 'twispay' ), 'administrator', 'twispay', 'twispay_tw_configuration' );
         add_submenu_page( 'twispay', __( $tw_lang['menu_transaction_tab'], 'twispay' ), __( $tw_lang['menu_transaction_tab'], 'twispay' ), 'administrator', 'tw-transaction', 'twispay_tw_transaction_administrator' );

--- a/Twispay WooCommerce Plugin/twispay/includes/admin/transaction-log/transaction-log.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/admin/transaction-log/transaction-log.php
@@ -6,13 +6,13 @@
  *
  * @package  Twispay/Admin
  * @category Admin
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 // Exit if the file is accessed directly
-if ( ! defined( 'ABSPATH' ) ) { 
-    exit; 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
 }
 
 function twispay_tw_transaction_log_administrator() {
@@ -24,7 +24,7 @@ function twispay_tw_transaction_log_administrator() {
     } else {
         require( TWISPAY_PLUGIN_DIR . 'lang/en/lang.php' );
     }
-    
+
     if ( ! class_exists( 'WooCommerce' ) ) {
         ?>
             <div class="error notice" style="margin-top: 20px;">

--- a/Twispay WooCommerce Plugin/twispay/includes/admin/transaction/recurring_t.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/admin/transaction/recurring_t.php
@@ -6,8 +6,8 @@
  *
  * @package  Twispay/Admin
  * @category Admin
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 // Load languages
@@ -17,13 +17,13 @@ if ( file_exists( TWISPAY_PLUGIN_DIR . 'lang/' . $lang . '/lang.php' ) ) {
     require( TWISPAY_PLUGIN_DIR . 'lang/' . $lang . '/lang.php' );
 } else {
     require( TWISPAY_PLUGIN_DIR . 'lang/en/lang.php' );
-} 
+}
 
 ?>
 <div class="wrap">
     <h2><?= $tw_lang['transaction_list_recurring_ptitle']; ?></h2>
     <p><?= $tw_lang['transaction_list_recurring_subtitle']; ?></p>
-    
+
     <!-- Get all payment order ID from the $_GET parameters -->
     <?php
         if ( isset( $_GET['order_ad'] ) && $_GET['order_ad'] ) {

--- a/Twispay WooCommerce Plugin/twispay/includes/admin/transaction/refund_t.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/admin/transaction/refund_t.php
@@ -6,8 +6,8 @@
  *
  * @package  Twispay/Admin
  * @category Admin
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 // Load languages
@@ -17,13 +17,13 @@ if ( file_exists( TWISPAY_PLUGIN_DIR . 'lang/' . $lang . '/lang.php' ) ) {
     require( TWISPAY_PLUGIN_DIR . 'lang/' . $lang . '/lang.php' );
 } else {
     require( TWISPAY_PLUGIN_DIR . 'lang/en/lang.php' );
-} 
+}
 
 ?>
 <div class="wrap">
     <h2><?= $tw_lang['transaction_list_refund_ptitle']; ?></h2>
     <p><?= $tw_lang['transaction_list_refund_subtitle']; ?></p>
-    
+
     <!-- Get all payment transactions ID from the $_GET parameters -->
     <?php
         if ( isset( $_GET['payment_ad'] ) && $_GET['payment_ad'] ) {
@@ -33,7 +33,7 @@ if ( file_exists( TWISPAY_PLUGIN_DIR . 'lang/' . $lang . '/lang.php' ) ) {
             }
         }
     ?>
-    
+
     <form method="post" id="refund_payment_transaction">
         <input type="hidden" name="tw_general_action" value="refund_payment_transaction" />
         <?php submit_button( $tw_lang['transaction_list_confirm_title'], 'primary', 'createuser', true, array( 'id' => 'confirmdeletion' ) ); ?>

--- a/Twispay WooCommerce Plugin/twispay/includes/admin/transaction/requests.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/admin/transaction/requests.php
@@ -6,8 +6,8 @@
  *
  * @package  Twispay/Admin
  * @category Admin
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 
@@ -191,7 +191,7 @@ function tw_twispay_p_synchronize_subscriptions( $request ) {
                     /* Cancel the local subscription as no order was found on the server. */
                     Twispay_TW_Status_Updater::updateSubscriptionStatus($subscription->get_parent_id(), Twispay_TW_Status_Updater::$RESULT_STATUSES['CANCEL_OK'], $tw_lang);
                 }
-    
+
                 /* Redirect to the Transaction list Page with success. */
                 wp_safe_redirect( admin_url( 'admin.php?page=tw-transaction&notice=success_recurring' ) );
             } else {

--- a/Twispay WooCommerce Plugin/twispay/includes/admin/transaction/transaction-table.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/admin/transaction/transaction-table.php
@@ -6,8 +6,8 @@
  *
  * @package  Twispay/Admin
  * @category Admin
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 // Add the copy of the WP_List_Table class. We made a copy because the class is private.
@@ -15,14 +15,11 @@ require_once TWISPAY_PLUGIN_DIR . 'includes/class-ma-list-table.php';
 
 /**
  * Base custom class for displaying a list of items in an ajaxified HTML table.
- *
- * @class       TransactionTable
- * @version	0.0.1
  */
 class Twispay_TransactionTable extends Twispay_Tw_List_Table {
-    
+
     protected $tw_lang;
-    
+
     /**
      * Constructor.
      *
@@ -51,16 +48,16 @@ class Twispay_TransactionTable extends Twispay_Tw_List_Table {
      */
     function __construct( $tw_lang ) {
         global $status, $page;
-        
+
         $this->tw_lang = $tw_lang;
-    
+
         parent::__construct( array(
-            'singular'  => 'notification',  
-            'plural'    => 'notifications',   
-            'ajax'      => false      
+            'singular'  => 'notification',
+            'plural'    => 'notifications',
+            'ajax'      => false
         ) );
     }
-    
+
     /**
      * Displays the search box.
      *
@@ -80,7 +77,7 @@ class Twispay_TransactionTable extends Twispay_Tw_List_Table {
         if ( isset( $_REQUEST['status'] ) && $_REQUEST['status'] ) {
             echo '<input type="hidden" name="status" value="' . esc_attr( $_REQUEST['status'] ) . '" />';
         }
-            
+
         ?>
             <p class="search-box">
                 <input type="search" id="<?php echo $input_id; ?>" name="s" value="<?php _admin_search_query(); ?>" />
@@ -88,23 +85,20 @@ class Twispay_TransactionTable extends Twispay_Tw_List_Table {
             </p>
         <?php
     }
- 
+
     /**
      * Custom function that retrive the number of Transactions
-     *
-     * @version 0.0.1
-     * @access  private
      *
      * @param Object $wpdb         Wordpress refference to database.
      */
     private function get_all_count( $wpdb ) {
         $table_name = $wpdb->prefix . 'twispay_tw_transactions  ';
-        
+
         $wpdb->get_results( "SELECT id_tw_transactions FROM $table_name" );
-        
+
         return $wpdb->num_rows;
     }
-    
+
     /**
      * Get an associative array ( id => link ) with the list
      * of views available on this table.
@@ -116,30 +110,27 @@ class Twispay_TransactionTable extends Twispay_Tw_List_Table {
      */
     function get_views() {
         global $wpdb;
-         
+
         $views = array();
         $current = ( ! empty( $_REQUEST['status'] ) ? $_REQUEST['status'] : 'all' );
-        
+
         //All link
         $class = ( $current == 'all' ? ' class="current"' :'' );
         $all_url = remove_query_arg( 'status' );
         $views['all'] = "<a href='{$all_url }' {$class} >" . $this->tw_lang['transaction_list_all_views'] . "<span class='view_count'> ( " . $this->get_all_count( $wpdb ) . " )</span></a>";
-        
+
         return $views;
     }
-   
+
     /**
      * Custom modification on name column
-     *
-     * @version 0.0.1
-     * @access  public
      */
     function column_id_tw_transactions( $item ) {
         $actions = array(
             'refund'                 => sprintf( '<a href="?page=%s&action=%s&payment_ad=%s">' . $this->tw_lang['transaction_list_refund_title'] . '</a>', $_REQUEST['page'], 'refund_payment', $item['transactionId'] ),
             'cancel_recurring'       => sprintf( '<a href="?page=%s&action=%s&order_ad=%s">' . $this->tw_lang['transaction_list_recurring_title'] . '</a>', $_REQUEST['page'], 'recurring_payment', $item['orderId'] )
         );
-        
+
         if ( $item['status'] == 'complete-ok' ) {
             return sprintf( '%1$s %2$s', $item['id_tw_transactions'], $this->row_actions( $actions ) );
         }
@@ -147,7 +138,7 @@ class Twispay_TransactionTable extends Twispay_Tw_List_Table {
             return $item['id_tw_transactions'];
         }
     }
-    
+
     /**
      *
      * @param object $item
@@ -155,7 +146,7 @@ class Twispay_TransactionTable extends Twispay_Tw_List_Table {
      */
     function column_default( $item, $column_name ) {
         global $woocommerce;
-        
+
         switch ( $column_name ) {
             case 'id_tw_transactions':
             case 'customer_name':
@@ -167,7 +158,7 @@ class Twispay_TransactionTable extends Twispay_Tw_List_Table {
                 return '#' . $item[$column_name];
         }
     }
-    
+
     /**
      *
      * @param object $item
@@ -175,11 +166,11 @@ class Twispay_TransactionTable extends Twispay_Tw_List_Table {
     function column_cb( $item ) {
         return sprintf(
             '<input type="checkbox" name="%1$s[]" value="%2$s" />',
-            $this->_args['singular'],  
-            $item['id_tw_transactions']                
+            $this->_args['singular'],
+            $item['id_tw_transactions']
         );
     }
-    
+
     /**
      * Get a list of columns. The format is:
      * 'internal-name' => 'Title'
@@ -202,7 +193,7 @@ class Twispay_TransactionTable extends Twispay_Tw_List_Table {
         );
         return $columns;
     }
-    
+
     /**
      * Get a list of sortable columns. The format is:
      * 'internal-name' => 'orderby'
@@ -225,7 +216,7 @@ class Twispay_TransactionTable extends Twispay_Tw_List_Table {
         );
         return $sortable_columns;
     }
-    
+
     /**
      * Prepares the list of items for displaying.
      * @uses TW_List_Table::set_pagination_args()
@@ -236,14 +227,14 @@ class Twispay_TransactionTable extends Twispay_Tw_List_Table {
      */
     function prepare_items() {
         global $wpdb;
-        
+
         $s = ( isset( $_REQUEST['s'] ) ? $_REQUEST['s'] : 'all' );
         $ma_status = ( isset( $_REQUEST['status'] ) ? $_REQUEST['status'] : 'all' );
         $order_by = ( isset( $_REQUEST['orderby'] ) ? $_REQUEST['orderby'] : '' );
         $order_how = ( isset( $_REQUEST['order'] ) ? $_REQUEST['order'] : 'asc' );
-        
+
         $transaction = $wpdb->prefix . "twispay_tw_transactions";
-        
+
         $per_page = 10;
         $query =
                 "SELECT
@@ -256,11 +247,11 @@ class Twispay_TransactionTable extends Twispay_Tw_List_Table {
                     tr.checkout_url
                 FROM $transaction tr
                 ";
-        
+
         if ( $s != 'all' ) {
             $query .= " WHERE tr.id_cart LIKE '%$s%'";
         }
-        
+
         // Order by functionality. Works on all columns.
         if ( $order_by != '' ) {
             switch ( $order_by ) {
@@ -274,23 +265,23 @@ class Twispay_TransactionTable extends Twispay_Tw_List_Table {
         else {
             $query .= " ORDER BY tr.id_tw_transactions desc";
         }
-    
+
         $columns = $this->get_columns();
         $hidden = array();
         $sortable = $this->get_sortable_columns();
-    
+
         $this->_column_headers = array( $columns, $hidden, $sortable );
         $this->process_bulk_action();
-        $data = $wpdb->get_results( $query, ARRAY_A );       
-    
+        $data = $wpdb->get_results( $query, ARRAY_A );
+
         // Set pagination to page.
-        $current_page = $this->get_pagenum();   
+        $current_page = $this->get_pagenum();
         $total_items = count( $data ) ;
-        $data = array_slice( $data, ( ( $current_page - 1 ) * $per_page ), $per_page ); 
+        $data = array_slice( $data, ( ( $current_page - 1 ) * $per_page ), $per_page );
         $this->items = $data;
-    
+
         $this->set_pagination_args( array(
-            'total_items'  => $total_items, 
+            'total_items'  => $total_items,
             'per_page'     => $per_page,
             'total_pages'  => ceil( $total_items / $per_page )
         ) );

--- a/Twispay WooCommerce Plugin/twispay/includes/admin/transaction/transaction.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/admin/transaction/transaction.php
@@ -6,13 +6,13 @@
  *
  * @package  Twispay/Admin
  * @category Admin
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 // Exit if the file is accessed directly
-if ( ! defined( 'ABSPATH' ) ) { 
-    exit; 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
 }
 
 // Import the table class

--- a/Twispay WooCommerce Plugin/twispay/includes/class-tw-payment-confirmation.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/class-tw-payment-confirmation.php
@@ -6,13 +6,13 @@
  *
  * @package  Twispay/Front
  * @category Front
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 // Exit if the file is accessed directly
-if ( ! defined( 'ABSPATH' ) ) { 
-    exit; 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
 }
 
 // Security class check
@@ -20,9 +20,6 @@ if ( ! class_exists( 'Twispay_TW_Payment_Confirmation' ) ) :
 
 /**
  * Twispay Payment Confirmation Class
- *
- * @class   Twispay_TW_Payment_Confirmation
- * @version 0.0.1
  */
 class Twispay_TW_Payment_Confirmation  {
     /**
@@ -32,15 +29,15 @@ class Twispay_TW_Payment_Confirmation  {
      * @return void
      */
     public function __construct() {
-	
+
     }
-    
+
     /**
      * Call and render the Twispay Payment Confirmation Form
      *
      * @public
      * @return string Payment Confirmation Form
-     */	
+     */
     public function twispay_tw_payment_confirmation_form() {
 	return TW()->views->twispay_tw_render_view( 'payment-confirmation' );
     }

--- a/Twispay WooCommerce Plugin/twispay/includes/class-tw-shortcodes.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/class-tw-shortcodes.php
@@ -6,13 +6,13 @@
  *
  * @package  Twispay/Admin
  * @category Admin
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 // Exit if the file is accessed directly
-if ( ! defined( 'ABSPATH' ) ) { 
-    exit; 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
 }
 
 // Security class check
@@ -20,9 +20,6 @@ if ( ! class_exists( 'Twispay_TW_Shortcodes' ) ) :
 
 /**
  * Twispay Shorcodes Class
- *
- * @class   Twispay_TW_Shortcodes
- * @version 0.0.1
  */
 class Twispay_TW_Shortcodes {
     /**
@@ -34,13 +31,13 @@ class Twispay_TW_Shortcodes {
     public function __construct() {
         add_shortcode( 'tw_payment_confirmation', array( $this, 'twispay_tw_payment_confirmation_handler' ) );
     }
-    
+
     /**
      * Renders the Twispay Payment Confirmation Form
      *
      * @public
      * @return string Payment Confirmation Form
-     */	
+     */
     public function twispay_tw_payment_confirmation_handler( $atts ) {
 	    return TW()->payment_confirmation->twispay_tw_payment_confirmation_form();
     }

--- a/Twispay WooCommerce Plugin/twispay/includes/class-tw-views.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/class-tw-views.php
@@ -6,13 +6,13 @@
  *
  * @package  Twispay/Front
  * @category Front
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 // Exit if the file is accessed directly
-if ( ! defined( 'ABSPATH' ) ) { 
-    exit; 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
 }
 
 // Security class check
@@ -20,9 +20,6 @@ if ( ! class_exists( 'Twispay_TW_Views' ) ) :
 
 /**
  * Twispay Views Class
- *
- * @class   Twispay_TW_Views
- * @version 0.0.1
  */
 class Twispay_TW_Views {
     /**
@@ -32,15 +29,15 @@ class Twispay_TW_Views {
      * @return void
      */
     public function __construct() {
-	
+
     }
-    
+
     /**
      * Render the Front Twispay View
      *
      * @public
      * @return string Individual view
-     */	
+     */
     public function twispay_tw_render_view( $slug ) {
 	      include TWISPAY_PLUGIN_DIR . 'views/' . $slug . '.php';
     }

--- a/Twispay WooCommerce Plugin/twispay/includes/install.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/install.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Twispay Install
+ *
+ * Installing Twispay user pages, tables, and options.
+ *
+ * @package  Twispay/Install
+ * @category Core
+ * @author   Twispay
+ * @version  1.0.8
+ */
+
 function twispay_wp_check_install() {
 	if( ! get_option( 'twispay_tw_installed' ) ) {
 		twispay_tw_install();
@@ -8,7 +19,7 @@ add_action( 'admin_init', 'twispay_wp_check_install' );
 
 function twispay_tw_install() {
 	update_option( 'twispay_tw_installed', '1' );
-	
+
 	// Create new pages from Twispay Confirmation with shortcodes included
 	wp_insert_post(
 		array(
@@ -20,10 +31,10 @@ function twispay_tw_install() {
 			'comment_status' => 'closed'
 		)
 	);
-	
+
 	// Create All tables
 	global $wpdb;
-	
+
 	$wpdb->get_results( "CREATE TABLE IF NOT EXISTS `" . $wpdb->prefix . "twispay_tw_configuration` (
 		`id_tw_configuration` int(10) NOT NULL AUTO_INCREMENT,
 		`live_mode` int(10) NOT NULL,
@@ -36,7 +47,7 @@ function twispay_tw_install() {
 		`contact_email` VARCHAR(50) NOT NULL DEFAULT '0',
 		PRIMARY KEY (`id_tw_configuration`)
 	) ENGINE=InnoDB  DEFAULT CHARSET=latin1 AUTO_INCREMENT=1" );
-	
+
 	$wpdb->get_results( "CREATE TABLE IF NOT EXISTS `" . $wpdb->prefix . "twispay_tw_transactions` (
 		`id_tw_transactions` int(10) NOT NULL AUTO_INCREMENT,
 		`status` varchar(50) NOT NULL,
@@ -49,7 +60,7 @@ function twispay_tw_install() {
 		`cardId` int(10) NOT NULL,
 		PRIMARY KEY (`id_tw_transactions`)
 	) ENGINE=InnoDB  DEFAULT CHARSET=latin1 AUTO_INCREMENT=1" );
-	
+
 	$wpdb->get_results( "INSERT INTO `" . $wpdb->prefix . "twispay_tw_configuration` (`live_mode`) VALUES (0);" );
 }
 register_activation_hook( TWISPAY_PLUGIN_DIR, 'twispay_tw_install' );

--- a/Twispay WooCommerce Plugin/twispay/includes/scripts.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/scripts.php
@@ -6,8 +6,8 @@
  *
  * @package  Twispay/Admin
  * @category Admin
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 /* Require the "Twispay_TW_Logger" class. */
@@ -26,18 +26,18 @@ function twispay_tw_check_if_is_admin() {
     if ( ! is_admin() ) {
         return false;
     }
-    
+
     // Check if the page parameters is present
     if ( ! isset( $_GET['page'] ) ) {
         return false;
     }
-    
+
     // Make array with all Twispay Pages
     $tw_pages = array(
         'twispay',
         'tw-transaction'
     );
-    
+
     // Check if current page is one of the Twispay Pages
     return in_array( $_GET['page'], $tw_pages );
 }
@@ -56,7 +56,7 @@ function twispay_tw_add_admin_js() {
     if ( ! twispay_tw_check_if_is_admin() ) {
         return;
     }
-    
+
     // Load all admin js files for Administrator Pages
     wp_enqueue_script( 'ma-admin', plugins_url( '../assets/js/admin.js', __FILE__ ) );
     //wp_enqueue_script( 'ma-admin-jquery', plugins_url( '../assets/js/jquery-ui.min.js', __FILE__ ) );
@@ -77,7 +77,7 @@ function twispay_tw_add_admin_css() {
     if ( ! twispay_tw_check_if_is_admin() ) {
         return;
     }
-    
+
     // Load all admin css files for Administrator Pages
     wp_enqueue_style( 'ma-admin', plugins_url( '../assets/css/admin.css', __FILE__ ) );
 }
@@ -132,7 +132,7 @@ function init_twispay_gateway_class() {
                 $this->method_description = $tw_lang['ws_description'];
                 if( class_exists('WC_Subscriptions') ){
                     $this->supports = [ 'products'
-                                      , 'refunds' 
+                                      , 'refunds'
                                       , 'subscriptions'
                                       , 'subscription_cancellation'
                                       , 'subscription_suspension'
@@ -307,24 +307,10 @@ function init_twispay_gateway_class() {
                 /* Check if the order contains a subscription. */
                 if(class_exists('WC_Subscriptions') && (TRUE == wcs_order_contains_subscription($order_id))){
                     /* Redirect to file that processes the subscriptions payments requests. */
-                    return array(
-                        'result' => 'success',
-                        'redirect' => plugin_dir_url( __FILE__ ) . 'twispay-subscription-processor.php?order_id=' . $order_id
-                    );
+                    return array('result' => 'success', 'redirect' => plugin_dir_url( __FILE__ ) . 'twispay-subscription-processor.php?order_id=' . $order_id);
                 } else {
-                    if ( isset( $_GET['tw_reload'] ) && $_GET['tw_reload'] ) {
-                        // Return request redirect
-                        return array(
-                            'result' => 'success',
-                            'redirect' => plugin_dir_url( __FILE__ ) . 'twispay-processor.php?order_id=' . $order_id . '&tw_reload=true'
-                        );
-                    } else {
-                        // Return request redirect
-                        return array(
-                            'result' => 'success',
-                            'redirect' => plugin_dir_url( __FILE__ ) . 'twispay-processor.php?order_id=' . $order_id
-                        );
-                    }
+                    /* Redirect to file that processes the purchase payments requests. */
+                    return array('result' => 'success', 'redirect' => plugin_dir_url( __FILE__ ) . 'twispay-processor.php?order_id=' . $order_id);
                 }
             }
 
@@ -335,7 +321,7 @@ function init_twispay_gateway_class() {
              * @param order_id: The ID of the order witha. the refund.
              * @param amount: The amount to be refunded.
              * @param reason: The reason of the refund.
-             * 
+             *
              * @return boolean: True or false based on success
              */
             function process_refund($order_id, $amount = NULL, $reason = '') {

--- a/Twispay WooCommerce Plugin/twispay/includes/twispay-processor.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/twispay-processor.php
@@ -6,8 +6,8 @@
  *
  * @package  Twispay/Admin
  * @category Admin
- * @author   twispay
- * @version  1.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 ?>
@@ -76,12 +76,16 @@ if ( isset( $_GET['order_id'] ) && $_GET['order_id'] ) {
                 $siteID = $configuration->staging_id;
                 $secretKey = $configuration->staging_key;
             } else {
-                /* TODO: Error? */
+                echo '<style>.loader {display: none;}</style>';
+                die( $tw_lang['twispay_processor_error_missing_configuration'] );
             }
         }
 
+        /** Save the timestamp of this payment. */
+        $timestamp = date('YmdHis');
+
         /* Extract the customer details. */
-        $customer = [ 'identifier' => (0 == $data['customer_id']) ? ('_' . $_GET['order_id'] . '_' . date('YmdHis')) : ('_' . $data['customer_id'] . '_' . date('YmdHis'))
+        $customer = [ 'identifier' => 'p_wo_' . ((0 == $data['customer_id']) ? ($_GET['order_id']) : ($data['customer_id'])) . '_' . $timestamp
                     , 'firstName' => ($data['billing']['first_name']) ? ($data['billing']['first_name']) : ($data['shipping']['first_name'])
                     , 'lastName' => ($data['billing']['last_name']) ? ($data['billing']['last_name']) : ($data['shipping']['last_name'])
                     , 'country' => ($data['billing']['country']) ? ($data['billing']['country']) : ($data['shipping']['country'])
@@ -114,7 +118,7 @@ if ( isset( $_GET['order_id'] ) && $_GET['order_id'] ) {
         /* Build the data object to be posted to Twispay. */
         $orderData = [ 'siteId' => $siteID
                      , 'customer' => $customer
-                     , 'order' => [ 'orderId' => (isset( $_GET['tw_reload'] ) && $_GET['tw_reload']) ? ($_GET['order_id'] . '_' . date('YmdHis')) : ($_GET['order_id'])
+                     , 'order' => [ 'orderId' => $_GET['order_id'] . '_' . $timestamp
                                   , 'type' => 'purchase'
                                   , 'amount' => $data['total']
                                   , 'currency' => $data['currency']

--- a/Twispay WooCommerce Plugin/twispay/includes/twispay-subscription-processor.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/twispay-subscription-processor.php
@@ -6,8 +6,8 @@
  *
  * @package  Twispay/Admin
  * @category Admin
- * @author   twispay
- * @version  1.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 ?>
 
@@ -82,8 +82,11 @@ if ( isset( $_GET['order_id'] ) && $_GET['order_id'] ) {
             }
         }
 
+        /** Save the timestamp of this payment. */
+        $timestamp = date('YmdHis');
+
         /* Extract the customer details. */
-        $customer = [ 'identifier' => (0 == $data['customer_id']) ? ('_' . $_GET['order_id'] . '_' . date('YmdHis')) : ('_' . $data['customer_id'] . '_' . date('YmdHis'))
+        $customer = [ 'identifier' => 'r_wo_' . ((0 == $data['customer_id']) ? ($_GET['order_id']) : ($data['customer_id'])) . '_' . $timestamp
                     , 'firstName' => ($data['billing']['first_name']) ? ($data['billing']['first_name']) : ($data['shipping']['first_name'])
                     , 'lastName' => ($data['billing']['last_name']) ? ($data['billing']['last_name']) : ($data['shipping']['last_name'])
                     , 'country' => ($data['billing']['country']) ? ($data['billing']['country']) : ($data['shipping']['country'])
@@ -136,7 +139,7 @@ if ( isset( $_GET['order_id'] ) && $_GET['order_id'] ) {
         /* Build the data object to be posted to Twispay. */
         $orderData = [ 'siteId' => $siteID
                      , 'customer' => $customer
-                     , 'order' => [ 'orderId' => $_GET['order_id']
+                     , 'order' => [ 'orderId' => $_GET['order_id'] . '_' . $timestamp
                                   , 'type' => 'recurring'
                                   , 'amount' => $data['total'] /* Total sum to pay right now. */
                                   , 'currency' => $data['currency']

--- a/Twispay WooCommerce Plugin/twispay/includes/validation.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/validation.php
@@ -5,8 +5,8 @@
  *
  * @package  Twispay/Front
  * @category Front
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 $parse_uri = explode( 'wp-content', $_SERVER['SCRIPT_FILENAME'] );

--- a/Twispay WooCommerce Plugin/twispay/includes/validation.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/validation.php
@@ -60,7 +60,7 @@ if ( '' == $secretKey ) {
 
 
 /* Extract the server response and decript it. */
-$decrypted = Twispay_TW_Helper_Response::twispay_tw_decrypt_message(/*tw_encryptedResponse*/(isset($_POST['opensslResult'])) ? ($_POST['opensslResult']) : ($_POST['result']), $secretKey);
+$decrypted = Twispay_TW_Helper_Response::twispay_tw_decrypt_message(/*tw_encryptedResponse*/(isset($_POST['opensslResult'])) ? ($_POST['opensslResult']) : ($_POST['result']), $secretKey, $tw_lang);
 
 
 /* Check if decryption failed.  */

--- a/Twispay WooCommerce Plugin/twispay/lang/en/lang.php
+++ b/Twispay WooCommerce Plugin/twispay/lang/en/lang.php
@@ -6,7 +6,8 @@
  *
  * @package  Twispay/Language
  * @category Admin/Front
- * @version  1.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 /* Configuration panel from Administrator */

--- a/Twispay WooCommerce Plugin/twispay/lang/en/lang.php
+++ b/Twispay WooCommerce Plugin/twispay/lang/en/lang.php
@@ -160,3 +160,17 @@ $tw_lang['general_error_hold_notice'] = ' Payment is on hold.';
 $tw_lang['general_error_invalid_key'] = ' Invalid secure key.';
 $tw_lang['general_error_invalid_order'] = ' Order does not exist.';
 $tw_lang['general_error_invalid_private'] = ' Private key is not valid.';
+
+
+/* JSON decoding/encoding errors */
+$tw_lang['JSON_ERROR_DEPTH'] = 'The maximum stack depth has been exceeded.';
+$tw_lang['JSON_ERROR_STATE_MISMATCH'] = 'Invalid or malformed JSON.';
+$tw_lang['JSON_ERROR_CTRL_CHAR'] = 'Control character error, possibly incorrectly encoded.';
+$tw_lang['JSON_ERROR_SYNTAX'] = 'Syntax error.';
+$tw_lang['JSON_ERROR_UTF8'] = 'Malformed UTF-8 characters, possibly incorrectly encoded.';
+$tw_lang['JSON_ERROR_RECURSION'] = 'One or more recursive references in the value to be encoded.';
+$tw_lang['JSON_ERROR_INF_OR_NAN'] = 'One or more NAN or INF values in the value to be encoded.';
+$tw_lang['JSON_ERROR_UNSUPPORTED_TYPE'] = 'A value of a type that cannot be encoded was given.';
+$tw_lang['JSON_ERROR_INVALID_PROPERTY_NAME'] = 'A property name that cannot be encoded was given.';
+$tw_lang['JSON_ERROR_UTF16'] = 'Malformed UTF-16 characters, possibly incorrectly encoded.';
+$tw_lang['JSON_ERROR_UNKNOWN'] = 'Unknown error.';

--- a/Twispay WooCommerce Plugin/twispay/lang/ro/lang.php
+++ b/Twispay WooCommerce Plugin/twispay/lang/ro/lang.php
@@ -6,7 +6,8 @@
  *
  * @package  Twispay/Language
  * @category Admin/Front
- * @version  1.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 /* Configuration panel from Administrator */

--- a/Twispay WooCommerce Plugin/twispay/lang/ro/lang.php
+++ b/Twispay WooCommerce Plugin/twispay/lang/ro/lang.php
@@ -160,3 +160,17 @@ $tw_lang['general_error_hold_notice'] = ' Plata este in asteptare.';
 $tw_lang['general_error_invalid_key'] = ' Cheie de siguranță nevalidă.';
 $tw_lang['general_error_invalid_order'] = ' Comanda nu există.';
 $tw_lang['general_error_invalid_private'] = ' Cheie privată nevalidă.';
+
+
+/* JSON decoding/encoding errors */
+$tw_lang['JSON_ERROR_DEPTH'] = 'Adancimea maxima a stivei a fost depasita.';
+$tw_lang['JSON_ERROR_STATE_MISMATCH'] = 'JSON invalid sau deformat.';
+$tw_lang['JSON_ERROR_CTRL_CHAR'] = 'Eroare la caracterul de control, posibil sa nu fie codificat corect.';
+$tw_lang['JSON_ERROR_SYNTAX'] = 'Eroare de sintaxa.';
+$tw_lang['JSON_ERROR_UTF8'] = 'Caractere UTF-8 deformate, posibil sa nu fie codificate corect.';
+$tw_lang['JSON_ERROR_RECURSION'] = 'Una sau mai multe referinte recursive in valorile care trebuie codificate.';
+$tw_lang['JSON_ERROR_INF_OR_NAN'] = 'Una sau mai multe valoru NAN sau INF in valorile care trebuie codificate.';
+$tw_lang['JSON_ERROR_UNSUPPORTED_TYPE'] = 'A fost trimisa o valoare de un tip ce nu poate fi codificat.';
+$tw_lang['JSON_ERROR_INVALID_PROPERTY_NAME'] = 'A fost trimis un nume de proprietate ce nu poate fi codificat.';
+$tw_lang['JSON_ERROR_UTF16'] = 'Caractere UTF-16 deformate, posibil sa nu fie codificate corect.';
+$tw_lang['JSON_ERROR_UNKNOWN'] = 'Eroare necunoscuta.';

--- a/Twispay WooCommerce Plugin/twispay/twispay.php
+++ b/Twispay WooCommerce Plugin/twispay/twispay.php
@@ -3,7 +3,7 @@
  * Plugin Name: Twispay Credit Card Payments
  * Plugin URI: https://wordpress.org/plugins/twispay/
  * Description: Plugin for Twispay payment gateway.
- * Version: 1.0.4
+ * Version: 1.0.7
  * Author: twispay
  * Author URI: https://www.twispay.com
  * License: GPLv2
@@ -12,8 +12,8 @@
  *
  * @package  Twispay
  * @category Core
- * @author   twispay
- * @version  1.0.4
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 // Exit if the file is accessed directly
@@ -26,9 +26,6 @@ if ( ! class_exists( 'Twispay' ) ) :
 
 /**
  * Main Twispay Class.
- *
- * @class   Twispay
- * @version 1.0.1
  */
 final class Twispay {
     /**

--- a/Twispay WooCommerce Plugin/twispay/uninstall.php
+++ b/Twispay WooCommerce Plugin/twispay/uninstall.php
@@ -6,8 +6,8 @@
  *
  * @package  Twispay/Uninstall
  * @category Core
- * @author   twispay
- * @version  1.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 // Exit if the file is accessed directly

--- a/Twispay WooCommerce Plugin/twispay/views/payment-confirmation.php
+++ b/Twispay WooCommerce Plugin/twispay/views/payment-confirmation.php
@@ -99,7 +99,7 @@ if ( '' == $secretKey ) {
 
 
 /* Extract the server response and decript it. */
-$decrypted = Twispay_TW_Helper_Response::twispay_tw_decrypt_message(/*tw_encryptedResponse*/(isset($_POST['opensslResult'])) ? ($_POST['opensslResult']) : ($_POST['result']), $secretKey);
+$decrypted = Twispay_TW_Helper_Response::twispay_tw_decrypt_message(/*tw_encryptedResponse*/(isset($_POST['opensslResult'])) ? ($_POST['opensslResult']) : ($_POST['result']), $secretKey, $tw_lang);
 
 
 /* Check if decryption failed.  */

--- a/Twispay WooCommerce Plugin/twispay/views/payment-confirmation.php
+++ b/Twispay WooCommerce Plugin/twispay/views/payment-confirmation.php
@@ -6,8 +6,8 @@
  *
  * @package  Twispay/Front
  * @category Front
- * @author   @TODO
- * @version  0.0.1
+ * @author   Twispay
+ * @version  1.0.8
  */
 
 /* Load languages */
@@ -190,6 +190,6 @@ if ( $_GET['secure_key'] != $order->get_data()['cart_hash'] ){
 /* Extract the transaction status. */
 $status = (empty($decrypted['status'])) ? ($decrypted['transactionStatus']) : ($decrypted['status']);
 /* Reconstruct the checkout URL to use it to allow client to try again in case of error. */
-$checkout_url = wc_get_checkout_url() . 'order-pay/' . $orderId . '/?pay_for_order=true&key=' . $order->get_data()['order_key'] . '&tw_reload=true';
+$checkout_url = wc_get_checkout_url() . 'order-pay/' . $orderId . '/?pay_for_order=true&key=' . $order->get_data()['order_key'];
 
 Twispay_TW_Status_Updater::updateStatus_backUrl($orderId, $status, $checkout_url, $tw_lang, $configuration);


### PR DESCRIPTION
Updated unique identifiers to reflect the request type (purchase or recurrent) and the source plugin.
Appended the timestamp to the orderId that is encapsulated inside the payment request to ensure unicity.
Tested with Wordpress 5.3