### PR TITLE
Tweaked logs logic

### DIFF
--- a/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Helper_Response.php
+++ b/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Helper_Response.php
@@ -186,7 +186,7 @@ if ( !class_exists( 'Twispay_TW_Helper_Response' ) ) :
                 }
 
                 Twispay_TW_Logger::twispay_tw_logTransaction( $data );
-                Twispay_TW_Logger::twispay_tw_log( $tw_lang['log_ok_validating_complete'] . $data['id_cart'] );
+                Twispay_TW_Logger::twispay_tw_log( sprintf($tw_lang['log_ok_validating_complete'], $data['id_cart']) );
 
                 return TRUE;
             }

--- a/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Logger.php
+++ b/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Logger.php
@@ -11,17 +11,22 @@
  */
 
 /* Exit if the file is accessed directly. */
-if ( !defined('ABSPATH') ) { exit; }
+if (!defined('ABSPATH')) {
+    exit;
+}
 
 /* Security class check */
-if ( ! class_exists( 'Twispay_TW_Logger' ) ) :
+if (!class_exists('Twispay_TW_Logger')) :
     /**
      * Twispay Helper Class
      *
      * Class that implements methods to log
      * messages and transactions.
      */
-    class Twispay_TW_Logger{
+    class Twispay_TW_Logger
+    {
+        const LOGS_PATH_OPTION_KEY = 'twispay_logs_path';
+
         /**
          * Function that logs a transaction to the DB.
          *
@@ -29,19 +34,20 @@ if ( ! class_exists( 'Twispay_TW_Logger' ) ) :
          *
          * @return void
          */
-        public static function twispay_tw_logTransaction( $data ) {
+        public static function twispay_tw_logTransaction($data)
+        {
             global $wpdb;
 
             /* Extract the WooCommerce order. */
             $order = wc_get_order($data['id_cart']);
 
-            $already = $wpdb->get_row( "SELECT * FROM " . $wpdb->prefix . "twispay_tw_transactions WHERE transactionId = '" . $data['transactionId'] . "'" );
-            if ( $already ) {
+            $already = $wpdb->get_row("SELECT * FROM " . $wpdb->prefix . "twispay_tw_transactions WHERE transactionId = '" . $data['transactionId'] . "'");
+            if ($already) {
                 /* Update the DB with the transaction data. */
-                $wpdb->query( $wpdb->prepare( "UPDATE " . $wpdb->prefix . "twispay_tw_transactions SET status = '" . $data['status'] . "' WHERE transactionId = '%d'", $data['transactionId'] ) );
+                $wpdb->query($wpdb->prepare("UPDATE " . $wpdb->prefix . "twispay_tw_transactions SET status = '" . $data['status'] . "' WHERE transactionId = '%d'", $data['transactionId']));
             } else {
                 $checkout_url = ((false !== $order) && (true !== $order)) ? (wc_get_checkout_url() . 'order-pay/' . explode('_', $data['id_cart'])[0] . '/?pay_for_order=true&key=' . $order->get_data()['order_key']) : ("");
-                $wpdb->get_results( "INSERT INTO `" . $wpdb->prefix . "twispay_tw_transactions` (`status`, `id_cart`, `identifier`, `orderId`, `transactionId`, `customerId`, `cardId`, `checkout_url`) VALUES ('" . $data['status'] . "', '" . $data['id_cart'] . "', '" . $data['identifier'] . "', '" . $data['orderId'] . "', '" . $data['transactionId'] . "', '" . $data['customerId'] . "', '" . $data['cardId'] . "', '" . $checkout_url . "');" );
+                $wpdb->get_results("INSERT INTO `" . $wpdb->prefix . "twispay_tw_transactions` (`status`, `id_cart`, `identifier`, `orderId`, `transactionId`, `customerId`, `cardId`, `checkout_url`) VALUES ('" . $data['status'] . "', '" . $data['id_cart'] . "', '" . $data['identifier'] . "', '" . $data['orderId'] . "', '" . $data['transactionId'] . "', '" . $data['customerId'] . "', '" . $data['cardId'] . "', '" . $checkout_url . "');");
             }
         }
 
@@ -54,13 +60,14 @@ if ( ! class_exists( 'Twispay_TW_Logger' ) ) :
          *
          * @return void
          */
-        public static function twispay_tw_updateTransactionStatus( $id, $status ) {
+        public static function twispay_tw_updateTransactionStatus($id, $status)
+        {
             global $wpdb;
 
-            $already = $wpdb->get_row( "SELECT * FROM " . $wpdb->prefix . "twispay_tw_transactions WHERE id_cart = '" . $id . "'" );
-            if ( $already ) {
+            $already = $wpdb->get_row("SELECT * FROM " . $wpdb->prefix . "twispay_tw_transactions WHERE id_cart = '" . $id . "'");
+            if ($already) {
                 /* Update the DB with the transaction data. */
-                $wpdb->query( $wpdb->prepare( "UPDATE " . $wpdb->prefix . "twispay_tw_transactions SET status = '" . $status . "' WHERE id_cart = '%d'", $id ) );
+                $wpdb->query($wpdb->prepare("UPDATE " . $wpdb->prefix . "twispay_tw_transactions SET status = '" . $status . "' WHERE id_cart = '%d'", $id));
             }
         }
 
@@ -72,13 +79,120 @@ if ( ! class_exists( 'Twispay_TW_Logger' ) ) :
          *
          * @return Void
          */
-        public static function twispay_tw_log( $message = FALSE ) {
-            $log_file = dirname( __FILE__ ) . '/../twispay-log.txt';
+        public static function twispay_tw_log($message = false)
+        {
+            self::migrate_old_logs();
+
             /* Build the log message. */
-            $message = (!$message) ? (PHP_EOL . PHP_EOL) : ("[" . date( 'Y-m-d H:i:s' ) . "] " . $message);
+            $message = (!$message) ? (PHP_EOL . PHP_EOL) : ("[" . date('Y-m-d H:i:s') . "] " . $message);
 
             /* Try to append log to file and silence and PHP errors may occur. */
-            @file_put_contents( $log_file, $message . PHP_EOL, FILE_APPEND );
+            @file_put_contents(self::twispay_get_log_file_path(), $message . PHP_EOL, FILE_APPEND);
+        }
+
+        /**
+         * Migrate the old log file to the new location
+         */
+        private static function migrate_old_logs()
+        {
+            if (get_option('twispay_log_is_migrated', false)) {
+                return;
+            }
+
+            if (is_readable(TWISPAY_PLUGIN_DIR . 'twispay-log.txt')) {
+                update_option('twispay_log_is_migrated', 1);
+                @rename(TWISPAY_PLUGIN_DIR . 'twispay-log.txt', self::twispay_get_log_file_path());
+            }
+        }
+
+        /**
+         * Generate a random dir name path to keep logs.
+         *
+         * @return string
+         */
+        public static function twispay_get_log_dir_path()
+        {
+            $savedPath = get_option(self::LOGS_PATH_OPTION_KEY, false);
+
+            if ($savedPath && is_dir($savedPath)) {
+                return $savedPath;
+            }
+
+            $upload_dir = wp_upload_dir();
+
+            $logsDir = $upload_dir['basedir'];
+            $logsDir .= '/twispay-' . substr(sha1(rand(PHP_INT_MIN, PHP_INT_MAX) . microtime() . get_bloginfo('url')), 0, 6);
+            $logsDir .= '/';
+
+            if (!is_dir($logsDir)) {
+                mkdir($logsDir, 0777, true);
+            }
+
+            update_option(self::LOGS_PATH_OPTION_KEY, $logsDir);
+
+            return $logsDir;
+        }
+
+        /**
+         * Log file path
+         *
+         * @return string
+         */
+        public static function twispay_get_log_file_path()
+        {
+            return self::twispay_get_log_dir_path() . '/twispay.log';
+        }
+
+        /**
+         * @return bool
+         */
+        public static function twispay_has_logs()
+        {
+            return file_exists(self::twispay_get_log_file_path());
+        }
+
+        /**
+         * Reads the log file
+         *
+         * @return false|string
+         */
+        public static function twispay_get_logs()
+        {
+            return file_get_contents(self::twispay_get_log_file_path());
+        }
+
+        /**
+         * Remove a directory
+         *
+         * @param $folder
+         */
+        private static function twispay_remove_folder($folder)
+        {
+            foreach (new DirectoryIterator($folder) as $f) {
+                if ($f->isDot()) {
+                    continue;
+                }
+
+                if ($f->isFile()) {
+                    unlink($f->getPathname());
+                    continue;
+                }
+
+                if ($f->isDir()) {
+                    self::twispay_remove_folder($f->getPathname());
+                    continue;
+                }
+            }
+
+            rmdir($folder);
+        }
+
+        /**
+         * Clear Twispay logs folder
+         */
+        public static function twispay_clear_logs()
+        {
+            self::twispay_remove_folder(self::twispay_get_log_dir_path());
         }
     }
 endif; /* End if class_exists. */

--- a/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Logger.php
+++ b/Twispay WooCommerce Plugin/twispay/helpers/Twispay_TW_Logger.php
@@ -16,234 +16,236 @@ if (!defined('ABSPATH')) {
 }
 
 /* Security class check */
-if (!class_exists('Twispay_TW_Logger')) :
+if (class_exists('Twispay_TW_Logger')) {
+    return;
+}
+
+/**
+ * Twispay Helper Class
+ *
+ * Class that implements methods to log
+ * messages and transactions.
+ */
+class Twispay_TW_Logger
+{
+    const LOGS_PATH_OPTION_KEY = 'twispay_logs_path';
+
     /**
-     * Twispay Helper Class
+     * Function that logs a transaction to the DB.
      *
-     * Class that implements methods to log
-     * messages and transactions.
+     * @param data Array containing the transaction data.
+     *
+     * @return void
      */
-    class Twispay_TW_Logger
+    public static function twispay_tw_logTransaction($data)
     {
-        const LOGS_PATH_OPTION_KEY = 'twispay_logs_path';
+        global $wpdb;
+        $tableName = "{$wpdb->prefix}twispay_tw_transactions";
 
-        /**
-         * Function that logs a transaction to the DB.
-         *
-         * @param data Array containing the transaction data.
-         *
-         * @return void
-         */
-        public static function twispay_tw_logTransaction($data)
-        {
-            global $wpdb;
-            $tableName = "{$wpdb->prefix}twispay_tw_transactions";
+        /* Extract the WooCommerce order. */
+        $order = wc_get_order($data['id_cart']);
 
-            /* Extract the WooCommerce order. */
-            $order = wc_get_order($data['id_cart']);
+        $already = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$tableName} WHERE transactionId = '%d'", $data['transactionId']));
 
-            $already = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$tableName} WHERE transactionId = '%d'", $data['transactionId']));
-
-            if ($already) {
-                /* Update the DB with the transaction data. */
-                $wpdb->update($tableName, [
-                    'status' => $data['status'],
-                ], [
-                    'transactionId' => $data['transactionId'],
-                ], [
-                    'status' => '%s',
-                ], [
-                    'transactionId' => '%d',
-                ]);
-                return;
-            }
-
-            $checkout_url = ((false !== $order) && (true !== $order)) ?
-                (wc_get_checkout_url() . 'order-pay/' . explode('_', $data['id_cart'])[0] . '/?pay_for_order=true&key=' . $order->get_data()['order_key']) :
-                ("");
-
-            $wpdb->insert($tableName, [
+        if ($already) {
+            /* Update the DB with the transaction data. */
+            $wpdb->update($tableName, [
                 'status' => $data['status'],
-                'id_cart' => $data['id_cart'],
-                'identifier' => $data['identifier'],
-                'orderId' => $data['orderId'],
+            ], [
                 'transactionId' => $data['transactionId'],
-                'customerId' => $data['customerId'],
-                'cardId' => $data['cardId'],
-                'checkout_url' => $checkout_url,
             ], [
                 'status' => '%s',
-                'id_cart' => '%d',
-                'identifier' => '%s',
-                'orderId' => '%d',
+            ], [
                 'transactionId' => '%d',
-                'customerId' => '%d',
-                'cardId' => '%d',
-                'checkout_url' => '%s',
             ]);
+            return;
         }
 
+        $checkout_url = ((false !== $order) && (true !== $order)) ?
+            (wc_get_checkout_url() . 'order-pay/' . explode('_', $data['id_cart'])[0] . '/?pay_for_order=true&key=' . $order->get_data()['order_key']) :
+            ("");
 
-        /**
-         * Function that updates a transaction's status in the DB.
-         *
-         * @param id The ID of the parent order.
-         * @param status The new status of the transaction.
-         *
-         * @return void
-         */
-        public static function twispay_tw_updateTransactionStatus($id, $status)
-        {
-            global $wpdb;
+        $wpdb->insert($tableName, [
+            'status' => $data['status'],
+            'id_cart' => $data['id_cart'],
+            'identifier' => $data['identifier'],
+            'orderId' => $data['orderId'],
+            'transactionId' => $data['transactionId'],
+            'customerId' => $data['customerId'],
+            'cardId' => $data['cardId'],
+            'checkout_url' => $checkout_url,
+        ], [
+            'status' => '%s',
+            'id_cart' => '%d',
+            'identifier' => '%s',
+            'orderId' => '%d',
+            'transactionId' => '%d',
+            'customerId' => '%d',
+            'cardId' => '%d',
+            'checkout_url' => '%s',
+        ]);
+    }
 
-            $tableName = "{
+
+    /**
+     * Function that updates a transaction's status in the DB.
+     *
+     * @param id The ID of the parent order.
+     * @param status The new status of the transaction.
+     *
+     * @return void
+     */
+    public static function twispay_tw_updateTransactionStatus($id, $status)
+    {
+        global $wpdb;
+
+        $tableName = "{
             $wpdb->prefix}twispay_tw_transactions";
 
-            $already = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$tableName} WHERE id_cart = '%d'", $id));
+        $already = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$tableName} WHERE id_cart = '%d'", $id));
 
-            if (!$already) {
-                return;
-            }
-
-            $wpdb->update($tableName, [
-                'status' => $status,
-            ], [
-                'id_cart' => $id,
-            ], [
-                'status' => '%s',
-            ], [
-                    'id_cart' => '%d',
-                ]
-            );
+        if (!$already) {
+            return;
         }
 
-
-        /**
-         * Function that logs a message to the log file.
-         *
-         * @param string - Message to log to file.
-         *
-         * @return Void
-         */
-        public static function twispay_tw_log($message = false)
-        {
-            self::migrate_old_logs();
-
-            /* Build the log message. */
-            $message = (!$message) ? (PHP_EOL . PHP_EOL) : ("[" . date('Y-m-d H:i:s') . "] " . $message);
-
-            /* Try to append log to file and silence and PHP errors may occur. */
-            @file_put_contents(self::twispay_get_log_file_path(), $message . PHP_EOL, FILE_APPEND);
-        }
-
-        /**
-         * Migrate the old log file to the new location
-         */
-        private static function migrate_old_logs()
-        {
-            if (get_option('twispay_log_is_migrated', false)) {
-                return;
-            }
-
-            if (!is_readable(TWISPAY_PLUGIN_DIR . 'twispay-log.txt')) {
-                return;
-            }
-
-            if (!rename(TWISPAY_PLUGIN_DIR . 'twispay-log.txt', self::twispay_get_log_file_path())) {
-                return;
-            }
-
-            update_option('twispay_log_is_migrated', 1);
-        }
-
-        /**
-         * Generate a random dir name path to keep logs.
-         *
-         * @return string
-         */
-        public static function twispay_get_log_dir_path()
-        {
-            $savedPath = get_option(self::LOGS_PATH_OPTION_KEY, false);
-
-            if ($savedPath && is_dir($savedPath)) {
-                return $savedPath;
-            }
-
-            $upload_dir = wp_upload_dir();
-
-            $logsDir = $upload_dir['basedir'];
-            $logsDir .= '/twispay-' . substr(sha1(rand(PHP_INT_MIN, PHP_INT_MAX) . microtime() . get_bloginfo('url')), 0, 6);
-            $logsDir .= '/';
-
-            if (!is_dir($logsDir)) {
-                mkdir($logsDir, 0777, true);
-            }
-
-            update_option(self::LOGS_PATH_OPTION_KEY, $logsDir);
-
-            return $logsDir;
-        }
-
-        /**
-         * Log file path
-         *
-         * @return string
-         */
-        public static function twispay_get_log_file_path()
-        {
-            return self::twispay_get_log_dir_path() . '/twispay.log';
-        }
-
-        /**
-         * @return bool
-         */
-        public static function twispay_has_logs()
-        {
-            return file_exists(self::twispay_get_log_file_path());
-        }
-
-        /**
-         * Reads the log file
-         *
-         * @return false|string
-         */
-        public static function twispay_get_logs()
-        {
-            return file_get_contents(self::twispay_get_log_file_path());
-        }
-
-        /**
-         * Remove a directory
-         *
-         * @param $folder
-         */
-        private static function twispay_remove_folder($folder)
-        {
-            foreach (new DirectoryIterator($folder) as $f) {
-                if ($f->isDot()) {
-                    continue;
-                }
-
-                if ($f->isFile()) {
-                    unlink($f->getPathname());
-                    continue;
-                }
-
-                if ($f->isDir()) {
-                    self::twispay_remove_folder($f->getPathname());
-                    continue;
-                }
-            }
-
-            rmdir($folder);
-        }
-
-        /**
-         * Clear Twispay logs folder
-         */
-        public static function twispay_clear_logs()
-        {
-            self::twispay_remove_folder(self::twispay_get_log_dir_path());
-        }
+        $wpdb->update($tableName, [
+            'status' => $status,
+        ], [
+            'id_cart' => $id,
+        ], [
+            'status' => '%s',
+        ], [
+                'id_cart' => '%d',
+            ]
+        );
     }
-endif; /* End if class_exists. */
+
+
+    /**
+     * Function that logs a message to the log file.
+     *
+     * @param string - Message to log to file.
+     *
+     * @return Void
+     */
+    public static function twispay_tw_log($message = false)
+    {
+        self::migrate_old_logs();
+
+        /* Build the log message. */
+        $message = (!$message) ? (PHP_EOL . PHP_EOL) : ("[" . date('Y-m-d H:i:s') . "] " . $message);
+
+        /* Try to append log to file and silence and PHP errors may occur. */
+        @file_put_contents(self::twispay_get_log_file_path(), $message . PHP_EOL, FILE_APPEND);
+    }
+
+    /**
+     * Migrate the old log file to the new location
+     */
+    private static function migrate_old_logs()
+    {
+        if (get_option('twispay_log_is_migrated', false)) {
+            return;
+        }
+
+        if (!is_readable(TWISPAY_PLUGIN_DIR . 'twispay-log.txt')) {
+            return;
+        }
+
+        if (!rename(TWISPAY_PLUGIN_DIR . 'twispay-log.txt', self::twispay_get_log_file_path())) {
+            return;
+        }
+
+        update_option('twispay_log_is_migrated', 1);
+    }
+
+    /**
+     * Generate a random dir name path to keep logs.
+     *
+     * @return string
+     */
+    public static function twispay_get_log_dir_path()
+    {
+        $savedPath = get_option(self::LOGS_PATH_OPTION_KEY, false);
+
+        if ($savedPath && is_dir($savedPath)) {
+            return $savedPath;
+        }
+
+        $upload_dir = wp_upload_dir();
+
+        $logsDir = $upload_dir['basedir'];
+        $logsDir .= '/twispay-' . substr(sha1(rand(PHP_INT_MIN, PHP_INT_MAX) . microtime() . get_bloginfo('url')), 0, 6);
+        $logsDir .= '/';
+
+        if (!is_dir($logsDir)) {
+            mkdir($logsDir, 0777, true);
+        }
+
+        update_option(self::LOGS_PATH_OPTION_KEY, $logsDir);
+
+        return $logsDir;
+    }
+
+    /**
+     * Log file path
+     *
+     * @return string
+     */
+    public static function twispay_get_log_file_path()
+    {
+        return self::twispay_get_log_dir_path() . '/twispay.log';
+    }
+
+    /**
+     * @return bool
+     */
+    public static function twispay_has_logs()
+    {
+        return file_exists(self::twispay_get_log_file_path());
+    }
+
+    /**
+     * Reads the log file
+     *
+     * @return false|string
+     */
+    public static function twispay_get_logs()
+    {
+        return file_get_contents(self::twispay_get_log_file_path());
+    }
+
+    /**
+     * Remove a directory
+     *
+     * @param $folder
+     */
+    private static function twispay_remove_folder($folder)
+    {
+        foreach (new DirectoryIterator($folder) as $f) {
+            if ($f->isDot()) {
+                continue;
+            }
+
+            if ($f->isFile()) {
+                unlink($f->getPathname());
+                continue;
+            }
+
+            if ($f->isDir()) {
+                self::twispay_remove_folder($f->getPathname());
+                continue;
+            }
+        }
+
+        rmdir($folder);
+    }
+
+    /**
+     * Clear Twispay logs folder
+     */
+    public static function twispay_clear_logs()
+    {
+        self::twispay_remove_folder(self::twispay_get_log_dir_path());
+    }
+}

--- a/Twispay WooCommerce Plugin/twispay/includes/admin/transaction-log/transaction-log.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/admin/transaction-log/transaction-log.php
@@ -11,41 +11,47 @@
  */
 
 // Exit if the file is accessed directly
-if ( ! defined( 'ABSPATH' ) ) {
+if (!defined('ABSPATH')) {
     exit;
 }
 
-function twispay_tw_transaction_log_administrator() {
+function twispay_tw_transaction_log_administrator()
+{
     // Load languages
-    $lang = explode( '-', get_bloginfo( 'language' ) );
+    $lang = explode('-', get_bloginfo('language'));
     $lang = $lang[0];
-    if ( file_exists( TWISPAY_PLUGIN_DIR . 'lang/' . $lang . '/lang.php' ) ) {
-        require( TWISPAY_PLUGIN_DIR . 'lang/' . $lang . '/lang.php' );
+    if (file_exists(TWISPAY_PLUGIN_DIR . 'lang/' . $lang . '/lang.php')) {
+        require(TWISPAY_PLUGIN_DIR . 'lang/' . $lang . '/lang.php');
     } else {
-        require( TWISPAY_PLUGIN_DIR . 'lang/en/lang.php' );
+        require(TWISPAY_PLUGIN_DIR . 'lang/en/lang.php');
     }
 
-    if ( ! class_exists( 'WooCommerce' ) ) {
+    if (!class_exists('WooCommerce')) {
         ?>
-            <div class="error notice" style="margin-top: 20px;">
-                <p><?= esc_html( $tw_lang['no_woocommerce_f'] ); ?> <a target="_blank" href="https://wordpress.org/plugins/woocommerce/"><?= esc_html( $tw_lang['no_woocommerce_s'] ); ?></a>.</p>
-                <div class="clearfix"></div>
-            </div>
+        <div class="error notice" style="margin-top: 20px;">
+            <p><?= esc_html($tw_lang['no_woocommerce_f']); ?> <a target="_blank"
+                                                                 href="https://wordpress.org/plugins/woocommerce/"><?= esc_html($tw_lang['no_woocommerce_s']); ?></a>.
+            </p>
+            <div class="clearfix"></div>
+        </div>
         <?php
-    }
-    else {
+    } else {
         ?>
-            <div class="wrap">
-                <h1><?= esc_html( $tw_lang['transaction_log_title'] ); ?></h1>
-                <p><?= esc_html( $tw_lang['transaction_log_subtitle'] ); ?></p>
-                <?php
-                    if ( file_exists( TWISPAY_PLUGIN_DIR . 'twispay-log.txt' ) ) {
-                        echo '<textarea readonly style="width: 900px; height: 386px; margin-top: 10px;">' . wp_kses( file_get_contents( TWISPAY_PLUGIN_DIR . 'twispay-log.txt' ), wp_kses_allowed_html( 'strip' ) ) . '</textarea>';
-                    } else {
-                        echo '<p>' . esc_html( $tw_lang['transaction_log_no_log'] ) . '</p>';
-                    }
-                ?>
-            </div>
+        <div class="wrap">
+            <h1><?= esc_html($tw_lang['transaction_log_title']); ?></h1>
+            <p><?= esc_html($tw_lang['transaction_log_subtitle']); ?></p>
+            <?php if (Twispay_TW_Logger::twispay_has_logs()): ?>
+                <textarea id="twispay-logs" readonly
+                          style="width: 900px; height: 386px; margin-top: 10px;"><?= wp_kses(Twispay_TW_Logger::twispay_get_logs(), wp_kses_allowed_html('strip')); ?></textarea>
+                <script>
+                    var textarea = document.getElementById('twispay-logs');
+                    textarea.scrollTop = textarea.scrollHeight;
+                </script>
+            <?php else : ?>
+                <p><?= esc_html($tw_lang['transaction_log_no_log']); ?></p>
+            <?php endif;
+            ?>
+        </div>
         <?php
     }
 }

--- a/Twispay WooCommerce Plugin/twispay/lang/en/lang.php
+++ b/Twispay WooCommerce Plugin/twispay/lang/en/lang.php
@@ -114,7 +114,7 @@ $tw_lang['log_ok_status_refund'] = '[RESPONSE]: Status refund-ok for order ID: '
 $tw_lang['log_ok_status_failed'] = '[RESPONSE]: Status failed for order ID: ';
 $tw_lang['log_ok_status_hold'] = '[RESPONSE]: Status on-hold for order ID: ';
 $tw_lang['log_ok_status_uncertain'] = '[RESPONSE]: Status uncertain for order ID: ';
-$tw_lang['log_ok_validating_complete'] = '[RESPONSE]: Validating completed for order ID: ';
+$tw_lang['log_ok_validating_complete'] = '[RESPONSE]: Validating completed for order ID: %s';
 
 $tw_lang['log_error_validating_failed'] = '[RESPONSE-ERROR]: Validation failed.';
 $tw_lang['log_error_decryption_error'] = '[RESPONSE-ERROR]: Decryption failed.';

--- a/Twispay WooCommerce Plugin/twispay/uninstall.php
+++ b/Twispay WooCommerce Plugin/twispay/uninstall.php
@@ -15,6 +15,9 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
     exit;
 }
 
+Twispay_TW_Logger::twispay_clear_logs();
+delete_option( Twispay_TW_Logger::LOGS_PATH_OPTION_KEY );
+
 delete_option( 'twispay_tw_installed' );
 
 // Delete All TW Twispay Pages


### PR DESCRIPTION
Several things are changed here:

1. Moved `twispay-log.txt` from plugins folder to `wp-content/uploads/twispay-HASH` folder (`hash` being a randomly...ish generated folder);
1. Moved all the log-related logic to `Twispay_TW_Logger` class;
1. Logs display will automatically scroll at the end;
1. Replace SQL statements with `$wpdb` methods.

Basically this one started due to the fact that `twispay-log.txt` was exposed and provided too much informations to curious eyes.