### PR TITLE
Fixes for woocommerce payment module

### DIFF
--- a/Twispay WooCommerce Plugin/twispay/includes/admin/transaction/transaction-table.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/admin/transaction/transaction-table.php
@@ -125,30 +125,7 @@ class Twispay_TransactionTable extends Twispay_Tw_List_Table {
      * Custom modification on name column
      */
     function column_id_tw_transactions( $item ) {
-        $actions = array(
-            'refund' => sprintf( '<a href="?page=%s&action=%s&payment_ad=%s">%s</a>',
-                esc_attr( $_REQUEST['page'] ),
-                'refund_payment',
-                esc_attr( $item['transactionId'] ),
-                esc_html( $this->tw_lang['transaction_list_refund_title'] )
-            ),
-            'cancel_recurring'  => sprintf( '<a href="?page=%s&action=%s&order_ad=%s">%s</a>',
-                esc_attr( $_REQUEST['page'] ),
-                'recurring_payment',
-                esc_attr( $item['orderId'] ),
-                esc_html( $this->tw_lang['transaction_list_recurring_title'] )
-            )
-        );
-
-        if ( $item['status'] == 'complete-ok' ) {
-            return sprintf( '%1$s %2$s',
-                $item['id_tw_transactions'],
-                $this->row_actions( $actions )
-            );
-        }
-        else {
-            return esc_attr( $item['id_tw_transactions'] );
-        }
+        return esc_attr( $item['id_tw_transactions'] );
     }
 
     /**

--- a/Twispay WooCommerce Plugin/twispay/includes/scripts.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/scripts.php
@@ -413,6 +413,7 @@ function init_twispay_gateway_class() {
                 }
                 
                 if ($reason) {
+                    $args['body']['reason'] = 'customer-demand';
                     $args['body']['message'] = $reason;
                 }
                 

--- a/Twispay WooCommerce Plugin/twispay/includes/scripts.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/scripts.php
@@ -150,8 +150,8 @@ function init_twispay_gateway_class() {
                 $this->init_form_fields();
                 $this->init_settings();
 
-                $this->title = $this->get_option( 'title' );
-                $this->description = $this->get_option( 'description' );
+                $this->title = empty( $this->get_option( 'title' ) ) ? 'Twispay' : $this->get_option( 'title' );
+                $this->description = empty( $this->get_option( 'description' ) ) ? $tw_lang['default_description'] : $this->get_option( 'description' );
                 $this->enable_for_methods = $this->get_option( 'enable_for_methods', array() );
                 $this->enable_for_virtual = $this->get_option( 'enable_for_virtual', 'yes' ) === 'yes' ? true : false;
 

--- a/Twispay WooCommerce Plugin/twispay/includes/scripts.php
+++ b/Twispay WooCommerce Plugin/twispay/includes/scripts.php
@@ -333,7 +333,7 @@ function init_twispay_gateway_class() {
 
                     return array(
                       'result' => 'success',
-                      'redirect' => esc_url(
+                      'redirect' => esc_url_raw(
                         add_query_arg(
                           $args,
                           $actual_link
@@ -356,7 +356,7 @@ function init_twispay_gateway_class() {
 
                     return array(
                       'result' => 'success',
-                      'redirect' => esc_url(
+                      'redirect' => esc_url_raw(
                         add_query_arg(
                           $args,
                           $actual_link

--- a/Twispay WooCommerce Plugin/twispay/lang/en/lang.php
+++ b/Twispay WooCommerce Plugin/twispay/lang/en/lang.php
@@ -173,3 +173,5 @@ $tw_lang['JSON_ERROR_UNSUPPORTED_TYPE'] = 'A value of a type that cannot be enco
 $tw_lang['JSON_ERROR_INVALID_PROPERTY_NAME'] = 'A property name that cannot be encoded was given.';
 $tw_lang['JSON_ERROR_UTF16'] = 'Malformed UTF-16 characters, possibly incorrectly encoded.';
 $tw_lang['JSON_ERROR_UNKNOWN'] = 'Unknown error.';
+
+$tw_lang['default_description'] = 'Pay with twispay';

--- a/Twispay WooCommerce Plugin/twispay/lang/ro/lang.php
+++ b/Twispay WooCommerce Plugin/twispay/lang/ro/lang.php
@@ -173,3 +173,5 @@ $tw_lang['JSON_ERROR_UNSUPPORTED_TYPE'] = 'A fost trimisa o valoare de un tip ce
 $tw_lang['JSON_ERROR_INVALID_PROPERTY_NAME'] = 'A fost trimis un nume de proprietate ce nu poate fi codificat.';
 $tw_lang['JSON_ERROR_UTF16'] = 'Caractere UTF-16 deformate, posibil sa nu fie codificate corect.';
 $tw_lang['JSON_ERROR_UNKNOWN'] = 'Eroare necunoscuta.';
+
+$tw_lang['default_description'] = 'Plateste cu Twispay';


### PR DESCRIPTION
- [x] Use raw url esc for usage of url in redirect
- [x] Use default title and description for payment choice twispay
- [x] Remove refund button and cancel subscription from twispay transactions list
- [x] Add reason for refund